### PR TITLE
Add missing git package for composer git clones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN pecl install swoole \
 RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer
 
-RUN apt-get update && apt-get install -y zip
+RUN apt-get update && apt-get install -y zip git


### PR DESCRIPTION
Fixed:
![Screenshot from 2019-05-10 11-13-52](https://user-images.githubusercontent.com/147145/57516499-209a4780-7315-11e9-9c32-e374db44d100.png)
